### PR TITLE
Support writing files in UTF8

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -209,7 +209,7 @@ class SaveSubtitle:
 
         output_path = get_incremented_filename(faster_whisper_output_dir_path, prefix, subtitle_format)
 
-        with open(output_path, "w") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             f.write(subtitle)
         return (output_path,)
 


### PR DESCRIPTION
Currently there is an error `'charmap' codec can't encode characters in position 34-35: character maps to <undefined>` when trying to transribe Arabic audio. This commit should fix that.